### PR TITLE
fix: set of LDFLAGS not compatiable with newest makepkg.conf

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,8 +6,8 @@
 
 pkgname=xf86-video-amdgpu-git
 _pkgname=${pkgname%-*}
-pkgver=22.0.0.r8.g4e011b9
-pkgrel=2
+pkgver=23.0.0.r15.g18995f1
+pkgrel=1
 pkgdesc="X.org amdgpu video driver (git version)"
 arch=('x86_64')
 url="https://xorg.freedesktop.org/"
@@ -39,7 +39,7 @@ build() {
   # See https://bugs.archlinux.org/task/55102 / https://bugs.archlinux.org/task/54845
   export CFLAGS=${CFLAGS/-fno-plt}
   export CXXFLAGS=${CXXFLAGS/-fno-plt}
-  export LDFLAGS=${LDFLAGS/,-z,now}
+  export LDFLAGS=${LDFLAGS/-Wl,-z,now}
 
   #CFLAGS+=' -fcommon' # https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common
 


### PR DESCRIPTION
The default value of LDFLAGS of makepkg.conf is changed
(See https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/commit/0f10f032b02bc7823b3ac11f4807b5515c996821)

Now it contains multiple -Wl options instead of one
```bash
LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
         -Wl,-z,pack-relative-relocs"
```

the old setting
```bash
export LDFLAGS=${LDFLAGS/-z,now}
```
leads an empty linker option `-Wl` that causes gcc claming that `Unrecognized option -Wl` and thus failing the build.

This PR fixes this bug by changing it to 

```bash
export LDFLAGS=${LDFLAGS/-Wl,-z,now}
```

